### PR TITLE
Minor eclipse docs fix

### DIFF
--- a/docs/eclipse_depths.rst
+++ b/docs/eclipse_depths.rst
@@ -23,7 +23,7 @@ This creates a parametric T-P profile according to `Madhusudhan & Seager 2009 <h
 
 Then, call the eclipse depth calculator::
 
-  from eclipse_depth_calculator import EclipseDepthCalculator
+  from platon.eclipse_depth_calculator import EclipseDepthCalculator
   calc = EclipseDepthCalculator(method="xsec") #"ktables" for correlated k
   wavelengths, depths = calc.compute_depths(p, Rs, Mp, Rp, Tstar)
   


### PR DESCRIPTION
Fixes a small typo in the importing of `EclipseDepthCalculator` in the "Eclipse depths" doc page. Thanks for a great package!