### PR TITLE
refactor: Optimize _get_data.py to skip downloading existing data.zip

### DIFF
--- a/platon/_get_data.py
+++ b/platon/_get_data.py
@@ -1,5 +1,4 @@
 from urllib.request import urlopen
-
 from pkg_resources import resource_filename
 from platon import __data_url__, __md5sum__
 
@@ -17,42 +16,46 @@ def get_data_if_needed():
         curr_md5sum = f.read().strip()
 
     if __md5sum__ != curr_md5sum:
-        print("Warning: data files are out of date.  To update, remove the PLATON data directory ({}) and PLATON will automatically download the latest data files on the next run.".format(resource_filename(__name__, "data/")))
-        
+        print("Warning: data files are out of date. To update, remove the PLATON data directory ({}) and PLATON will automatically download the latest data files on the next run.".format(resource_filename(__name__, "data/")))
 
 def get_data(target_dir):
-    MB_TO_BYTES = 2**20
     filename = "data.zip"
-    print("Data URL", __data_url__)
-
-    #Bad! Dangerous! But necessary...get a real certificate, Caltech!
-    ctx = ssl.create_default_context()
-    ctx.check_hostname = False
-    ctx.verify_mode = ssl.CERT_NONE
-    u = urlopen(__data_url__, context=ctx)
-    f = open(filename, 'wb')
-
-    #Only for Python 3, because we don't support Python 2 anymore
-    file_size = int(u.getheader("Content-Length"))
-
-    print("Downloading {}: {:.0f} MB".format(
-        filename, file_size / MB_TO_BYTES))
-
-    bytes_downloaded = 0
-    block_sz = 8192
-    while True:
-        buffer = u.read(block_sz)
-        if not buffer:
-            break
-
-        bytes_downloaded += len(buffer)
-        f.write(buffer)
-        percentage = int(100 * bytes_downloaded / file_size)
-        status = "{:.0f} MB  [{}%]".format(
-            bytes_downloaded / MB_TO_BYTES, percentage)
-        print(status, end="\r")
-
-    f.close()
+    
+    # Check if data.zip already exists
+    if os.path.exists(filename):
+        print(f"'{filename}' already exists. Skipping.")
+    else:
+        MB_TO_BYTES = 2**20
+        print("Data URL", __data_url__)
+        
+        # Bad! Dangerous! But necessary...get a real certificate, Caltech!
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        u = urlopen(__data_url__, context=ctx)
+        f = open(filename, 'wb')
+        
+        # Only for Python 3, because we don't support Python 2 anymore
+        file_size = int(u.getheader("Content-Length"))
+        
+        print("Downloading {}: {:.0f} MB".format(
+            filename, file_size / MB_TO_BYTES))
+        
+        bytes_downloaded = 0
+        block_sz = 8192
+        while True:
+            buffer = u.read(block_sz)
+            if not buffer:
+                break
+            
+            bytes_downloaded += len(buffer)
+            f.write(buffer)
+            percentage = int(100 * bytes_downloaded / file_size)
+            status = "{:.0f} MB  [{}%]".format(
+                bytes_downloaded / MB_TO_BYTES, percentage)
+            print(status, end="\r")
+        
+        f.close()
 
     print("\nExtracting...")
     zip_ref = zipfile.ZipFile(filename, 'r')
@@ -64,9 +67,9 @@ def get_data(target_dir):
         curr_md5sum = hashlib.md5(f.read()).hexdigest()
 
     if curr_md5sum != __md5sum__:
-        raise RuntimeError("Downloaded data file is corrupt (wrong md5sum).  Please try again.")
-    
+        raise RuntimeError("Downloaded data file is corrupt (wrong md5sum). Please try again.")
+
     with open(resource_filename(__name__, "md5sum"), "w") as f:
         f.write(curr_md5sum)
-        
+
     os.remove(filename)


### PR DESCRIPTION
Check if data.zip already exists then skip download and continue extract file
- For people who already have the files and prefer not to re-download them from astro.uchicago.edu, we've added the option to use separate files. This is because the CDN can be slow in some countries due to its distance.